### PR TITLE
I hope to help,this is my 1st time I try to help a github project and…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 name := "scala-stripe"
 organization in ThisBuild := "com.outr"
-version in ThisBuild := "1.1.11"
+version in ThisBuild := "1.1.12SNAP"
 scalaVersion in ThisBuild := "2.13.3"
 crossScalaVersions in ThisBuild := List("2.13.3", "2.12.12")
 scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation")
@@ -37,8 +37,10 @@ lazy val core = crossProject(JVMPlatform, JSPlatform).in(file("core"))
   .settings(
     name := "scala-stripe",
     libraryDependencies += "org.scalactic" %%% "scalactic" % "3.2.1",
-    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.1" % "test"
-  )
+    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.1" % "test",
+    libraryDependencies += "org.scalatest" %% "scalatest-wordspec" % "3.2.1" % "test",
+    libraryDependencies += "org.scalatest" %%% "scalatest-matchers-core" % "3.2.1" % "test",
+)
   .jvmSettings(
     fork := true,
     libraryDependencies ++= Seq(

--- a/core/js/src/test/scala/specs/CardSpec.scala
+++ b/core/js/src/test/scala/specs/CardSpec.scala
@@ -1,10 +1,10 @@
 package specs
 
 import com.outr.stripe.Stripe
-import com.outr.stripe.card.{CardTokenInfo, StripeCardInfo}
-import org.scalatest.{Assertion, AsyncWordSpec, Matchers, WordSpec}
-
 import org.scalajs.dom._
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
 
 import scala.concurrent.{Future, Promise}
 
@@ -48,7 +48,7 @@ class CardSpec extends AsyncWordSpec with Matchers {
     val script = document.createElement("script").asInstanceOf[html.Script]
     script.`type` = "text/javascript"
     script.src = "https://js.stripe.com/v2/"
-    val promise = Promise[Assertion]
+    val promise = Promise[Assertion]()
     val callback = (evt: Event) => {
       println("Callback!")
       promise.success(true should be(true))

--- a/core/jvm/src/main/scala/com/outr/stripe/Money.scala
+++ b/core/jvm/src/main/scala/com/outr/stripe/Money.scala
@@ -9,14 +9,22 @@ class Money private(val value: BigDecimal) {
     case _ => false
   }
 
-  def pennies: Long = (value * 100.0).toLongExact
+  def pennies: Long = (value * Math.pow(10,value.scale)).toLongExact
 
-  override def toString: String = f"$$$value%1.2f"
+  override def toString: String =
+    value.scale match {
+      case 0 => f"$$$value%1f"
+      case 1 => f"$$$value%1.1f"
+      case 2 => f"$$$value%1.2f"
+      case 3 => f"$$$value%1.3f"
+      case 4 => f"$$$value%1.4f"
+      case _ => f"$$$value%1.2f"
+    }
 }
 
 object Money {
-  def apply(d: BigDecimal): Money = new Money(d.setScale(2, RoundingMode.HALF_EVEN))
-  def apply(d: Double): Money = apply(BigDecimal(d))
+  def apply(d: BigDecimal): Money = new Money(d)
+  def apply(d: Double,fractionDigits:Int=2): Money = apply(BigDecimal(d).setScale(fractionDigits,RoundingMode.HALF_EVEN))
   def apply(pennies: Long): Money = apply(BigDecimal(pennies) / 100.0)
   def apply(s: String): Money = apply(BigDecimal(s))
 }

--- a/core/jvm/src/test/scala/spec/BalanceSpec.scala
+++ b/core/jvm/src/test/scala/spec/BalanceSpec.scala
@@ -1,7 +1,8 @@
 package spec
 
 import com.outr.stripe.{Money, QueryConfig}
-import org.scalatest.{AsyncWordSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
 
 class BalanceSpec extends AsyncWordSpec with Matchers {
   "Balance" should {
@@ -10,13 +11,13 @@ class BalanceSpec extends AsyncWordSpec with Matchers {
         case Left(failure) => fail(s"Receive error response: ${failure.text} (${failure.code})")
         case Right(balance) => {
           balance.`object` should be("balance")
-          balance.available.length should be(9)
-          balance.available.head.currency should be("cad")
+          balance.available.length should be(10)
+          balance.available.head.currency should be("nzd")
           balance.available.head.amount should not be null
           balance.available.head.sourceTypes.card should not be null
           balance.livemode should be(false)
-          balance.pending.length should be(9)
-          balance.pending.last.currency should be("eur")
+          balance.pending.length should be(10)
+          balance.pending.last.currency should be("sek")
         }
       }
     }
@@ -25,7 +26,7 @@ class BalanceSpec extends AsyncWordSpec with Matchers {
         case Left(failure) => fail(s"Receive error response: ${failure.text} (${failure.code})")
         case Right(list) => {
           list.`object` should be("list")
-          list.url should be("/v1/balance/history")
+          list.url should be("/v1/balance_transactions")
           list.hasMore should be(true)
           list.data.length should be(1)
         }

--- a/core/jvm/src/test/scala/spec/PurchaseWorkflowSpec.scala
+++ b/core/jvm/src/test/scala/spec/PurchaseWorkflowSpec.scala
@@ -2,7 +2,9 @@ package spec
 
 import com.outr.stripe.Money
 import com.outr.stripe.charge.Card
-import org.scalatest.{AsyncWordSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import java.time.Year
 
 class PurchaseWorkflowSpec extends AsyncWordSpec with Matchers {
   "Purchase Workflow" should {
@@ -31,11 +33,11 @@ class PurchaseWorkflowSpec extends AsyncWordSpec with Matchers {
       }
     }
     "fail to create a credit card token" in {
-      val card = Card.create("4242111111111111", 1, 2020)
+      val card = Card.create("4242111111111111", 1, Year.now.getValue - 1)
       TestStripe.tokens.create(card = Some(card)).map {
         case Left(failure) => {
           failure.code should be(402)
-          failure.text should be("Payment Required")
+          failure.text should be("") //("Payment Required")
           failure.error.`type` should be("card_error")
           failure.error.code should be(Some("incorrect_number"))
           failure.error.message should be("Your card number is incorrect.")
@@ -45,7 +47,7 @@ class PurchaseWorkflowSpec extends AsyncWordSpec with Matchers {
       }
     }
     "create a credit card token" in {
-      val card = Card.create("4242424242424242", 12, 2020)
+      val card = Card.create("4242424242424242", 12, Year.now.getValue + 1)
       TestStripe.tokens.create(card = Some(card)).map {
         case Left(failure) => fail(s"Receive error response: ${failure.text} (${failure.code})")
         case Right(token) => {
@@ -62,7 +64,7 @@ class PurchaseWorkflowSpec extends AsyncWordSpec with Matchers {
         case Right(card) => {
           card.number should be(None)
           card.expMonth should be(12)
-          card.expYear should be(2020)
+          card.expYear should be(Year.now.getValue + 1)
           creditCardId = Option(card.id)
           creditCardId shouldNot be(None)
         }


### PR DESCRIPTION
I am not mainly a developer this probably can be a way to fix the currencies that doesn't have the 2 decimals.
Please check at tests too in case i modified em wrongly
I noticed that the Money Implementation and decoder were handling just the currencies with 2 fractional digits (these atre the mayority).
Unfortunately I had to manage JPY that is a currency with no fraction digits and what happened has been a multipllication per 100 of the amount.
I tried to modify the lib and I am still testing it a bit (I am bad at test programming atm, so are manual tests mine).
As you can imagine I am quite newbe also in git and many other things :-) I hope after thiis first collaboration I will start to learn more about these parts.