### PR TITLE
Chance to elaborate currencies with not just precision 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 name := "scala-stripe"
 organization in ThisBuild := "com.outr"
-version in ThisBuild := "1.1.11"
+version in ThisBuild := "1.1.12SNAP"
 scalaVersion in ThisBuild := "2.13.3"
 crossScalaVersions in ThisBuild := List("2.13.3", "2.12.12")
 scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation")
@@ -37,8 +37,10 @@ lazy val core = crossProject(JVMPlatform, JSPlatform).in(file("core"))
   .settings(
     name := "scala-stripe",
     libraryDependencies += "org.scalactic" %%% "scalactic" % "3.2.1",
-    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.1" % "test"
-  )
+    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.1" % "test",
+    libraryDependencies += "org.scalatest" %% "scalatest-wordspec" % "3.2.1" % "test",
+    libraryDependencies += "org.scalatest" %%% "scalatest-matchers-core" % "3.2.1" % "test",
+)
   .jvmSettings(
     fork := true,
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 name := "scala-stripe"
 organization in ThisBuild := "com.outr"
-version in ThisBuild := "1.1.12SNAP_FRAC_DIG"
+version in ThisBuild := "1.1.12-SNAPSHOT"
 scalaVersion in ThisBuild := "2.13.3"
 crossScalaVersions in ThisBuild := List("2.13.3", "2.12.12")
 scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation")

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 name := "scala-stripe"
 organization in ThisBuild := "com.outr"
-version in ThisBuild := "1.1.12SNAP"
+version in ThisBuild := "1.1.12SNAP_FRAC_DIG"
 scalaVersion in ThisBuild := "2.13.3"
 crossScalaVersions in ThisBuild := List("2.13.3", "2.12.12")
 scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation")

--- a/core/js/src/test/scala/specs/CardSpec.scala
+++ b/core/js/src/test/scala/specs/CardSpec.scala
@@ -1,10 +1,10 @@
 package specs
 
 import com.outr.stripe.Stripe
-import com.outr.stripe.card.{CardTokenInfo, StripeCardInfo}
-import org.scalatest.{Assertion, AsyncWordSpec, Matchers, WordSpec}
-
 import org.scalajs.dom._
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
 
 import scala.concurrent.{Future, Promise}
 
@@ -48,7 +48,7 @@ class CardSpec extends AsyncWordSpec with Matchers {
     val script = document.createElement("script").asInstanceOf[html.Script]
     script.`type` = "text/javascript"
     script.src = "https://js.stripe.com/v2/"
-    val promise = Promise[Assertion]
+    val promise = Promise[Assertion]()
     val callback = (evt: Event) => {
       println("Callback!")
       promise.success(true should be(true))

--- a/core/jvm/src/main/scala/com/outr/stripe/Implicits.scala
+++ b/core/jvm/src/main/scala/com/outr/stripe/Implicits.scala
@@ -24,7 +24,7 @@ trait Implicits {
   protected implicit val moneyDecoder: Decoder[Money] = new Decoder[Money] {
     override def apply(c: HCursor): Result[Money] = Decoder.decodeLong(c) match {
       case Left(failure) => Left(failure)
-      case Right(l) => Right(Money(l))
+      case Right(l) => Right(Money(l))//missing scale information
     }
   }
   protected implicit val transferDecoder: Decoder[Transfer] = deriveDecoder[Transfer]

--- a/core/jvm/src/main/scala/com/outr/stripe/Money.scala
+++ b/core/jvm/src/main/scala/com/outr/stripe/Money.scala
@@ -9,14 +9,22 @@ class Money private(val value: BigDecimal) {
     case _ => false
   }
 
-  def pennies: Long = (value * 100.0).toLongExact
+  def pennies: Long = (value * Math.pow(10,value.scale)).toLongExact
 
-  override def toString: String = f"$$$value%1.2f"
+  override def toString: String =
+    value.scale match {
+      case 0 => f"$$$value%1f"
+      case 1 => f"$$$value%1.1f"
+      case 2 => f"$$$value%1.2f"
+      case 3 => f"$$$value%1.3f"
+      case 4 => f"$$$value%1.4f"
+      case _ => f"$$$value%1.2f"
+    }
 }
 
 object Money {
-  def apply(d: BigDecimal): Money = new Money(d.setScale(2, RoundingMode.HALF_EVEN))
-  def apply(d: Double): Money = apply(BigDecimal(d))
+  def apply(d: BigDecimal): Money = new Money(d)
+  def apply(d: Double,fractionDigits:Int=2): Money = apply(BigDecimal(d).setScale(fractionDigits,RoundingMode.HALF_EVEN))
   def apply(pennies: Long): Money = apply(BigDecimal(pennies) / 100.0)
   def apply(s: String): Money = apply(BigDecimal(s))
 }

--- a/core/jvm/src/main/scala/com/outr/stripe/Money.scala
+++ b/core/jvm/src/main/scala/com/outr/stripe/Money.scala
@@ -11,20 +11,26 @@ class Money private(val value: BigDecimal) {
 
   def pennies: Long = (value * Math.pow(10,value.scale)).toLongExact
 
-  override def toString: String =
-    value.scale match {
-      case 0 => f"$$$value%1f"
-      case 1 => f"$$$value%1.1f"
-      case 2 => f"$$$value%1.2f"
-      case 3 => f"$$$value%1.3f"
-      case 4 => f"$$$value%1.4f"
-      case _ => f"$$$value%1.2f"
-    }
+  override def toString: String = pennies.toString
+
+//  amount
+//  positive integer or zero
+//  Amount intended to be collected by this payment.
+//  A positive integer representing how much to charge in the smallest currency unit
+//  (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency).
+//  The minimum amount is $0.50 US or equivalent in charge currency.
+//  The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).
 }
 
 object Money {
   def apply(d: BigDecimal): Money = new Money(d)
-  def apply(d: Double,fractionDigits:Int=2): Money = apply(BigDecimal(d).setScale(fractionDigits,RoundingMode.HALF_EVEN))
-  def apply(pennies: Long): Money = apply(BigDecimal(pennies) / 100.0)
+
+  def apply(number:AnyVal,fractionDigits:Int=2): Money =
+  number match {
+    case i:Int=>apply(BigDecimal(i.toDouble).setScale(fractionDigits,RoundingMode.HALF_EVEN))
+    case d:Double=>apply(BigDecimal(d).setScale(fractionDigits,RoundingMode.HALF_EVEN))
+    case pennies:Long =>apply((BigDecimal(pennies) / Math.pow(10,fractionDigits)).setScale(fractionDigits,RoundingMode.HALF_EVEN))
+    case _ => throw new NumberFormatException(s"The only permitted types are Int, Double or Long(as fractions).")
+  }
   def apply(s: String): Money = apply(BigDecimal(s))
 }

--- a/core/jvm/src/main/scala/com/outr/stripe/charge/Charge.scala
+++ b/core/jvm/src/main/scala/com/outr/stripe/charge/Charge.scala
@@ -1,5 +1,7 @@
 package com.outr.stripe.charge
 
+import java.util.Currency
+
 import com.outr.stripe.dispute.Dispute
 import com.outr.stripe.refund.Refund
 import com.outr.stripe.{Money, StripeList}
@@ -37,4 +39,7 @@ case class Charge(id: String,
                   sourceTransfer: Option[String],
                   statementDescriptor: Option[String],
                   status: String,
-                  transfer: Option[String])
+                  transfer: Option[String]){
+  val fixAmount=Money(amount.pennies,Currency.getInstance(currency.toUpperCase()).getDefaultFractionDigits)
+  val fixAmountRefunded=Money(amountRefunded.pennies,Currency.getInstance(currency.toUpperCase()).getDefaultFractionDigits)
+}

--- a/core/jvm/src/main/scala/com/outr/stripe/refund/Refund.scala
+++ b/core/jvm/src/main/scala/com/outr/stripe/refund/Refund.scala
@@ -10,6 +10,9 @@ case class Refund(id: String,
                   created: Long,
                   currency: String,
                   metadata: Map[String, String],
+                  paymentIntent: Option[String],
                   reason: Option[String],
-                  receiptNumber: String,
-                  status: String)
+                  receiptNumber: Option[String],
+                  sourceTransferReversal: Option[String],
+                  status: String,
+                  transfer_reversal: Option[String])

--- a/core/jvm/src/main/scala/com/outr/stripe/support/RefundsSupport.scala
+++ b/core/jvm/src/main/scala/com/outr/stripe/support/RefundsSupport.scala
@@ -13,6 +13,7 @@ class RefundsSupport(stripe: Stripe) extends Implicits {
              refundApplicationFee: Boolean = false,
              reverseTransfer: Boolean = false): Future[Either[ResponseError, Refund]] = {
     val data = List(
+      write("charge", chargeId),
       write("amount", amount),
       write("metadata", metadata),
       write("reason", reason),

--- a/core/jvm/src/test/scala/spec/BalanceSpec.scala
+++ b/core/jvm/src/test/scala/spec/BalanceSpec.scala
@@ -1,7 +1,8 @@
 package spec
 
 import com.outr.stripe.{Money, QueryConfig}
-import org.scalatest.{AsyncWordSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
 
 class BalanceSpec extends AsyncWordSpec with Matchers {
   "Balance" should {
@@ -10,13 +11,13 @@ class BalanceSpec extends AsyncWordSpec with Matchers {
         case Left(failure) => fail(s"Receive error response: ${failure.text} (${failure.code})")
         case Right(balance) => {
           balance.`object` should be("balance")
-          balance.available.length should be(9)
-          balance.available.head.currency should be("cad")
+          balance.available.length should be(10)
+          balance.available.head.currency should be("nzd")
           balance.available.head.amount should not be null
           balance.available.head.sourceTypes.card should not be null
           balance.livemode should be(false)
-          balance.pending.length should be(9)
-          balance.pending.last.currency should be("eur")
+          balance.pending.length should be(10)
+          balance.pending.last.currency should be("sek")
         }
       }
     }
@@ -25,7 +26,7 @@ class BalanceSpec extends AsyncWordSpec with Matchers {
         case Left(failure) => fail(s"Receive error response: ${failure.text} (${failure.code})")
         case Right(list) => {
           list.`object` should be("list")
-          list.url should be("/v1/balance/history")
+          list.url should be("/v1/balance_transactions")
           list.hasMore should be(true)
           list.data.length should be(1)
         }

--- a/core/jvm/src/test/scala/spec/MoneyTest.scala
+++ b/core/jvm/src/test/scala/spec/MoneyTest.scala
@@ -1,0 +1,62 @@
+package spec
+
+import com.outr.stripe.{Implicits, Money}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+class MoneyTest  extends AsyncWordSpec with Matchers with Implicits {
+
+      "moneys should be equal" in {
+        Money(5.0) should be(Money("5.0"))
+        Money(5,0) should be(Money("5"))
+        Money(5,1) should be(Money("5"))
+        Money(5.toDouble) should be(Money("5"))
+        Money(5) should be(Money("5"))
+        Money(5,3) should be(Money("5"))
+        Money(0.05) should be(Money("0.05"))
+        Money(5.0) should be(Money(500L))
+        Money(5) should be(Money(500L))
+        Money(0.05) should be(Money(5L))
+
+        Money(5.0).pennies should be(Money("5.00").pennies)
+        Money(5,0).pennies should be(Money("5").pennies)
+        Money(5,1).pennies should be(Money("5.0").pennies)
+        Money(5.toDouble).pennies should be(Money("5.00").pennies)
+        Money(5).pennies should be(Money("5.00").pennies)
+        Money(5,3).pennies should be(Money("5.000").pennies)
+        Money(0.05).pennies should be(Money("0.05").pennies)
+        Money(0.05).pennies should be(Money(5L).pennies)
+        Money(5).pennies should be(Money(500L).pennies)
+        Money(5.0).pennies should be(Money(500L).pennies)
+
+        Money(5.0).toString should be(Money("5.00").toString)
+        Money(5,0).toString should be(Money("5").toString)
+        Money(5,1).toString should be(Money("5.0").toString)
+        Money(5.toDouble).toString should be(Money("5.00").toString)
+        Money(5).toString should be(Money("5.00").toString)
+        Money(5,3).toString should be(Money("5.000").toString)
+        Money(0.05).toString should be(Money("0.05").toString)
+        Money(5.0).toString should be(Money(500L).toString)
+        Money(5).toString should be(Money(500L).toString)
+        Money(0.05).toString should be(Money(5L).toString)
+
+
+        Money("5.0") should be(Money(500L))
+        Money("5.00").pennies should be(Money(500L).pennies)
+        Money("5.0").value should be(Money(500L).value)
+        Money("5.00").toString should be(Money(500L).toString)
+
+        Money("5").toString should be("5")
+        Money("5.0").toString should be("50")
+        Money("5.00").toString should be("500")
+        Money("5.000").toString should be("5000")
+
+        write("", Money("5.00"))(moneyEncoder) should be(Map(""->"500"))
+        write("", Money("5"))(moneyEncoder) should be(Map(""->"5"))
+        write("", Money(5.00))(moneyEncoder) should be(Map(""->"500"))
+        write("", Money(5))(moneyEncoder) should be(Map(""->"500"))
+        write("", Money(BigDecimal(5)setScale(2,BigDecimal.RoundingMode.HALF_EVEN)))(moneyEncoder) should be(Map(""->"500"))
+        write("", Money(BigDecimal("5")setScale(2,BigDecimal.RoundingMode.HALF_EVEN)))(moneyEncoder) should be(Map(""->"500"))
+        write("", Money(BigDecimal("5.0")setScale(2,BigDecimal.RoundingMode.HALF_EVEN)))(moneyEncoder) should be(Map(""->"500"))
+        write("", Money(BigDecimal("5.00")setScale(2,BigDecimal.RoundingMode.HALF_EVEN)))(moneyEncoder) should be(Map(""->"500"))
+      }
+}

--- a/core/jvm/src/test/scala/spec/MoneyTest.scala
+++ b/core/jvm/src/test/scala/spec/MoneyTest.scala
@@ -54,9 +54,9 @@ class MoneyTest  extends AsyncWordSpec with Matchers with Implicits {
         write("", Money("5"))(moneyEncoder) should be(Map(""->"5"))
         write("", Money(5.00))(moneyEncoder) should be(Map(""->"500"))
         write("", Money(5))(moneyEncoder) should be(Map(""->"500"))
-        write("", Money(BigDecimal(5)setScale(2,BigDecimal.RoundingMode.HALF_EVEN)))(moneyEncoder) should be(Map(""->"500"))
-        write("", Money(BigDecimal("5")setScale(2,BigDecimal.RoundingMode.HALF_EVEN)))(moneyEncoder) should be(Map(""->"500"))
-        write("", Money(BigDecimal("5.0")setScale(2,BigDecimal.RoundingMode.HALF_EVEN)))(moneyEncoder) should be(Map(""->"500"))
-        write("", Money(BigDecimal("5.00")setScale(2,BigDecimal.RoundingMode.HALF_EVEN)))(moneyEncoder) should be(Map(""->"500"))
+        write("", Money(BigDecimal(5).setScale(2,BigDecimal.RoundingMode.HALF_EVEN)))(moneyEncoder) should be(Map(""->"500"))
+        write("", Money(BigDecimal("5").setScale(2,BigDecimal.RoundingMode.HALF_EVEN)))(moneyEncoder) should be(Map(""->"500"))
+        write("", Money(BigDecimal("5.0").setScale(2,BigDecimal.RoundingMode.HALF_EVEN)))(moneyEncoder) should be(Map(""->"500"))
+        write("", Money(BigDecimal("5.00").setScale(2,BigDecimal.RoundingMode.HALF_EVEN)))(moneyEncoder) should be(Map(""->"500"))
       }
 }

--- a/core/jvm/src/test/scala/spec/MoneyTestWs.sc
+++ b/core/jvm/src/test/scala/spec/MoneyTestWs.sc
@@ -1,0 +1,7 @@
+import com.outr.stripe.Money
+
+println(BigDecimal("5").scale)
+println(Money(BigDecimal("5")).value.scale)
+println(Money(BigDecimal(5)).value.scale)
+println(Money("5"))
+

--- a/core/jvm/src/test/scala/spec/PurchaseWorkflowSpec.scala
+++ b/core/jvm/src/test/scala/spec/PurchaseWorkflowSpec.scala
@@ -70,9 +70,9 @@ class PurchaseWorkflowSpec extends AsyncWordSpec with Matchers {
         }
       }
     }
-    "make a purchase with the test customer" in {
-      TestStripe.charges.create(Money(5.0), "USD", customer = customerId).map {
-        case Left(failure) => fail(s"Receive error response: ${failure.text} (${failure.code})")
+    "make a purchase with the test customer USD no pennies" in {
+      TestStripe.charges.create(Money(5), "USD", customer = customerId).map {
+        case Left(failure) => fail(s"Receive error response: ${failure.text} - ${failure.error} (${failure.code})")
         case Right(charge) => {
           charge.amount should be(Money(500L))
           charge.captured should be(true)
@@ -81,6 +81,65 @@ class PurchaseWorkflowSpec extends AsyncWordSpec with Matchers {
           charge.source.id should be(creditCardId.get)
           charge.status should be("succeeded")
         }
+      }
+    }
+    "make a purchase with the test customer USD pennies" in {
+      TestStripe.charges.create(Money(5.00), "USD", customer = customerId).map {
+        case Left(failure) => fail(s"Receive error response: ${failure.text} - ${failure.error} (${failure.code})")
+        case Right(charge) => {
+          charge.amount should be(Money(500L))
+          charge.captured should be(true)
+          charge.failureCode should be(None)
+          charge.failureMessage should be(None)
+          charge.source.id should be(creditCardId.get)
+          charge.status should be("succeeded")
+        }
+      }
+    }
+    "make a purchase with the test customer USD pennies String" in {
+      TestStripe.charges.create(Money("5.00"), "USD", customer = customerId).map {
+        case Left(failure) => fail(s"Receive error response: ${failure.text} - ${failure.error} (${failure.code})")
+        case Right(charge) => {
+          charge.amount should be(Money(500L))
+          charge.captured should be(true)
+          charge.failureCode should be(None)
+          charge.failureMessage should be(None)
+          charge.source.id should be(creditCardId.get)
+          charge.status should be("succeeded")
+        }
+      }
+    }
+    "make a purchase with the test customer JPY" in {
+      TestStripe.charges.create(Money("5000"), "JPY", customer = customerId).map {
+        case Left(failure) => fail(s"Receive error response: ${failure.text} - ${failure.error} (${failure.code})")
+        case Right(charge) => {
+          charge.amount should be(Money(5000L))
+          charge.captured should be(true)
+          charge.failureCode should be(None)
+          charge.failureMessage should be(None)
+          charge.source.id should be(creditCardId.get)
+          charge.status should be("succeeded")
+        }
+      }
+    }
+    "make a purchase with the test customer JPY 500" in {
+      TestStripe.charges.create(Money("500"), "JPY", customer = customerId).map {
+        case Left(failure) => fail(s"Receive error response: ${failure.text} - ${failure.error} (${failure.code})")
+        case Right(charge) => {
+          charge.amount should be(Money(500L))
+          charge.captured should be(true)
+          charge.failureCode should be(None)
+          charge.failureMessage should be(None)
+          charge.source.id should be(creditCardId.get)
+          charge.status should be("succeeded")
+        }
+      }
+    }
+    "make a purchase with the test customer JPY 5" in {
+      TestStripe.charges.create(Money("5"), "JPY", customer = customerId).map {
+        case Left(failure) =>
+          failure.error.code should be("amount_too_small")
+        case Right(charge) => fail("Was supposed to fail, but did not!")
       }
     }
     "delete a credit card" in {

--- a/core/jvm/src/test/scala/spec/PurchaseWorkflowSpec.scala
+++ b/core/jvm/src/test/scala/spec/PurchaseWorkflowSpec.scala
@@ -2,7 +2,9 @@ package spec
 
 import com.outr.stripe.Money
 import com.outr.stripe.charge.Card
-import org.scalatest.{AsyncWordSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import java.time.Year
 
 class PurchaseWorkflowSpec extends AsyncWordSpec with Matchers {
   "Purchase Workflow" should {
@@ -31,11 +33,11 @@ class PurchaseWorkflowSpec extends AsyncWordSpec with Matchers {
       }
     }
     "fail to create a credit card token" in {
-      val card = Card.create("4242111111111111", 1, 2020)
+      val card = Card.create("4242111111111111", 1, Year.now.getValue - 1)
       TestStripe.tokens.create(card = Some(card)).map {
         case Left(failure) => {
           failure.code should be(402)
-          failure.text should be("Payment Required")
+          failure.text should be("") //("Payment Required")
           failure.error.`type` should be("card_error")
           failure.error.code should be(Some("incorrect_number"))
           failure.error.message should be("Your card number is incorrect.")
@@ -45,7 +47,7 @@ class PurchaseWorkflowSpec extends AsyncWordSpec with Matchers {
       }
     }
     "create a credit card token" in {
-      val card = Card.create("4242424242424242", 12, 2020)
+      val card = Card.create("4242424242424242", 12, Year.now.getValue + 1)
       TestStripe.tokens.create(card = Some(card)).map {
         case Left(failure) => fail(s"Receive error response: ${failure.text} (${failure.code})")
         case Right(token) => {
@@ -62,7 +64,7 @@ class PurchaseWorkflowSpec extends AsyncWordSpec with Matchers {
         case Right(card) => {
           card.number should be(None)
           card.expMonth should be(12)
-          card.expYear should be(2020)
+          card.expYear should be(Year.now.getValue + 1)
           creditCardId = Option(card.id)
           creditCardId shouldNot be(None)
         }

--- a/core/jvm/src/test/scala/spec/PurchaseWorkflowSpec.scala
+++ b/core/jvm/src/test/scala/spec/PurchaseWorkflowSpec.scala
@@ -74,7 +74,7 @@ class PurchaseWorkflowSpec extends AsyncWordSpec with Matchers {
       TestStripe.charges.create(Money(5), "USD", customer = customerId).map {
         case Left(failure) => fail(s"Receive error response: ${failure.text} - ${failure.error} (${failure.code})")
         case Right(charge) => {
-          charge.amount should be(Money(500L))
+          charge.amount.pennies should be(Money(500L).pennies)
           charge.captured should be(true)
           charge.failureCode should be(None)
           charge.failureMessage should be(None)
@@ -87,7 +87,7 @@ class PurchaseWorkflowSpec extends AsyncWordSpec with Matchers {
       TestStripe.charges.create(Money(5.00), "USD", customer = customerId).map {
         case Left(failure) => fail(s"Receive error response: ${failure.text} - ${failure.error} (${failure.code})")
         case Right(charge) => {
-          charge.amount should be(Money(500L))
+          charge.amount.pennies  should be(Money(500L).pennies )
           charge.captured should be(true)
           charge.failureCode should be(None)
           charge.failureMessage should be(None)
@@ -100,7 +100,7 @@ class PurchaseWorkflowSpec extends AsyncWordSpec with Matchers {
       TestStripe.charges.create(Money("5.00"), "USD", customer = customerId).map {
         case Left(failure) => fail(s"Receive error response: ${failure.text} - ${failure.error} (${failure.code})")
         case Right(charge) => {
-          charge.amount should be(Money(500L))
+          charge.amount.pennies should be(Money(500L).pennies )
           charge.captured should be(true)
           charge.failureCode should be(None)
           charge.failureMessage should be(None)
@@ -113,7 +113,7 @@ class PurchaseWorkflowSpec extends AsyncWordSpec with Matchers {
       TestStripe.charges.create(Money("5000"), "JPY", customer = customerId).map {
         case Left(failure) => fail(s"Receive error response: ${failure.text} - ${failure.error} (${failure.code})")
         case Right(charge) => {
-          charge.amount should be(Money(5000L))
+          charge.amount.pennies  should be(Money(5000L).pennies )
           charge.captured should be(true)
           charge.failureCode should be(None)
           charge.failureMessage should be(None)
@@ -126,7 +126,7 @@ class PurchaseWorkflowSpec extends AsyncWordSpec with Matchers {
       TestStripe.charges.create(Money("500"), "JPY", customer = customerId).map {
         case Left(failure) => fail(s"Receive error response: ${failure.text} - ${failure.error} (${failure.code})")
         case Right(charge) => {
-          charge.amount should be(Money(500L))
+          charge.amount.pennies  should be(Money(500L).pennies )
           charge.captured should be(true)
           charge.failureCode should be(None)
           charge.failureMessage should be(None)


### PR DESCRIPTION
Tried to adapt the code to manage also currencies that doesn t have digits or that have different dthan 2 digits after the decimal point (unfortunately I cannot test the non 2 or 0 because stripe at the moment is not supporting them if I am in right)