### PR TITLE
fix: Fixed refund support error with charge id.

### DIFF
--- a/core/jvm/src/main/scala/com/outr/stripe/refund/Refund.scala
+++ b/core/jvm/src/main/scala/com/outr/stripe/refund/Refund.scala
@@ -10,6 +10,9 @@ case class Refund(id: String,
                   created: Long,
                   currency: String,
                   metadata: Map[String, String],
+                  paymentIntent: Option[String],
                   reason: Option[String],
-                  receiptNumber: String,
-                  status: String)
+                  receiptNumber: Option[String],
+                  sourceTransferReversal: Option[String],
+                  status: String,
+                  transfer_reversal: Option[String])

--- a/core/jvm/src/main/scala/com/outr/stripe/support/RefundsSupport.scala
+++ b/core/jvm/src/main/scala/com/outr/stripe/support/RefundsSupport.scala
@@ -13,6 +13,7 @@ class RefundsSupport(stripe: Stripe) extends Implicits {
              refundApplicationFee: Boolean = false,
              reverseTransfer: Boolean = false): Future[Either[ResponseError, Refund]] = {
     val data = List(
+      write("charge", chargeId),
       write("amount", amount),
       write("metadata", metadata),
       write("reason", reason),


### PR DESCRIPTION
- Parameter chargeId is needed for perform a refund.

- Refund model has some missing field and paymentIntent is optional.